### PR TITLE
Support for oneOf/allOf/anyOf and improved parameter output

### DIFF
--- a/src/@types/enjoi/index.d.ts
+++ b/src/@types/enjoi/index.d.ts
@@ -4,6 +4,6 @@ declare module "enjoi" {
 
   export default {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    schema: (schemaObj: OpenAPIV3.SchemaObject) => Joi.AnySchema,
+    schema: (schemaObj: OpenAPIV3.SchemaObject, options?: any) => Joi.AnySchema,
   }
 }

--- a/src/__snapshots__/openapi-schema-to-code.test.ts.snap
+++ b/src/__snapshots__/openapi-schema-to-code.test.ts.snap
@@ -8,8 +8,10 @@ import Joi from \\"joi\\"
 export const schemas = {
   parameters: {
     get: {
-      item_id: Joi.string().required().min(1),
-      extra: Joi.boolean().optional(),
+      path: Joi.object({ item_id: Joi.string().required().min(1) }),
+      query: Joi.object({ extra: Joi.boolean().optional() }),
+      header: Joi.object({}),
+      cookie: Joi.object({}),
     },
   },
   components: {
@@ -17,13 +19,28 @@ export const schemas = {
       field1: Joi.string().required().email({}),
       field2: Joi.number().required().integer(),
       field3: Joi.number().max(10).min(0).multiple(0.1),
-      field4: Joi.string().pattern(
-        /^(\\\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(.[0-9]+)?(Z|(\\\\+|-)([01][0-9]|2[0-3]):([0-5][0-9]))$/i,
-        { name: \\"JsonSchema date-time format\\" }
-      ),
+      field4: Joi.date(),
       field5: Joi.string().allow(\\"option1\\", \\"option2\\").only(),
     }).unknown(),
     Component2: Joi.string().allow(\\"option1\\", \\"option2\\").only(),
+    Component3: Joi.alternatives()
+      .match(\\"all\\")
+      .try(Joi.string().allow(\\"\\").min(0), Joi.number()),
+    Component4: Joi.alternatives()
+      .match(\\"any\\")
+      .try(Joi.string().allow(\\"\\").min(0), Joi.number()),
+    Component5: Joi.alternatives()
+      .match(\\"one\\")
+      .try(
+        Joi.object({
+          pet_type: Joi.string().allow(\\"\\").required().min(0),
+          hunt: Joi.boolean(),
+        }).unknown(),
+        Joi.object({
+          pet_type: Joi.string().allow(\\"\\").required().min(0),
+          bark: Joi.boolean(),
+        }).unknown()
+      ),
   },
 };
 "

--- a/src/fixtures/example1.json
+++ b/src/fixtures/example1.json
@@ -84,6 +84,33 @@
       "Component2": {
         "enum": ["option1", "option2"],
         "type": "string"
+      },
+      "Component3": {
+        "allOf": [{ "type": "string" }, { "type": "number" }]
+      },
+      "Component4": {
+        "anyOf": [{ "type": "string" }, { "type": "number" }]
+      },
+      "Component5": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": ["pet_type"],
+            "properties": {
+              "pet_type": { "type": "string" },
+              "hunt": { "type": "boolean" }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["pet_type"],
+            "properties": {
+              "pet_type": { "type": "string" },
+              "bark": { "type": "boolean" }
+            }
+          }
+        ],
+        "discriminator": { "propertyName": "pet_type" }
       }
     }
   }

--- a/src/joi-schema-to-code.test.ts
+++ b/src/joi-schema-to-code.test.ts
@@ -561,4 +561,29 @@ describe("joiSchemaToCode()", () => {
       expect(joiSchemaToCode(schema)).toEqual(expected)
     })
   })
+
+  describe("alternatives schema", () => {
+    it.each([
+      [
+        Joi.alternatives()
+          .try(Joi.string().pattern(/^foo/), Joi.string().pattern(/bar$/))
+          .match("all"),
+        'Joi.alternatives().match("all").try(Joi.string().pattern(/^foo/,{}),Joi.string().pattern(/bar$/,{}))',
+      ],
+      [
+        Joi.alternatives()
+          .try(Joi.string().pattern(/^foo/), Joi.string().pattern(/bar$/))
+          .match("any"),
+        'Joi.alternatives().match("any").try(Joi.string().pattern(/^foo/,{}),Joi.string().pattern(/bar$/,{}))',
+      ],
+      [
+        Joi.alternatives()
+          .try(Joi.string().pattern(/^foo/), Joi.string().pattern(/bar$/))
+          .match("one"),
+        'Joi.alternatives().match("one").try(Joi.string().pattern(/^foo/,{}),Joi.string().pattern(/bar$/,{}))',
+      ],
+    ])("returns expected value", (schema, expected) => {
+      expect(joiSchemaToCode(schema)).toEqual(expected)
+    })
+  })
 })


### PR DESCRIPTION
Hi @marcduez! Thanks for building `openapi-to-joi`.

To give some context: I've been using `openapi-to-joi` on a private project to generate Joi validations for Hapi.js from an OpenAPI spec. There was some functionality that I found missing while using `openapi-to-joi`, so I would love to contribute them back.

In this PR:
- Support for [oneOf/allOf/anyOf](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/) through `Joi.alternatives()`
- Support for OpenAPI v3 [nullable](https://github.com/tlivings/enjoi#options) (using `enjoi`'s `refineSchema`) 
- Support for [parameter types](https://swagger.io/docs/specification/describing-parameters/). At the moment all parameters are merged into a common object with no additional attributes so it's not possible to identify if they are parameters for the `path`, `query`, etc. This change fixes that but changes the resulting `parameters` by output by grouping them. Making them easier to be re-used as Joi validations.

The support for parameter types changes the output format for parameters so it should probably go into a new major version following semver, but that's up to you.